### PR TITLE
enable newlines on education/experience/about description

### DIFF
--- a/src/components/cards/AboutCard.tsx
+++ b/src/components/cards/AboutCard.tsx
@@ -6,64 +6,23 @@ import {
   IonCardHeader,
   IonCardTitle,
   IonCol,
-  IonFooter,
   IonGrid,
-  IonModal,
-  IonRow,
-  IonTextarea
+  IonRow
 } from '@ionic/react';
 import styled from 'styled-components';
 
+import {
+  LinkStyleSpan,
+  MyModal,
+  MyGrid,
+  MyTextarea,
+  ModalFooter
+} from './common';
 import styleWidget from './WidgetCards.module.scss';
 
-const LinkStyleSpan = styled.span`
-  font-family: 'SF Pro Display';
-  font-size: 14px;
-  font-weight: 500;
-  font-stretch: normal;
-  font-style: normal;
-  line-height: normal;
-  letter-spacing: -0.07px;
-  text-align: left;
-  color: #4c6fff;
-  cursor: pointer;
-`;
-
-const MyModal = styled(IonModal)`
-  --border-radius: 16px;
-  --min-height: 200px;
-  --height: 280px;
-  --width: 560px;
-`;
-
-const MyGrid = styled(IonGrid)`
-  margin: 10px 20px 10px 20px;
-  height: 100 %;
-`;
-const MyTextarea = styled(IonTextarea)`
-  width: 90 %;
-  margin-top: 15px;
-  background: #edf2f7;
-  box-shadow: 0px 1px 2px rgba(50, 50, 71, 0.08),
-    0px 0px 1px rgba(50, 50, 71, 0.2);
-  border-radius: 6px;
-  font-size: 13px;
-  font-weight: 500;
-  font-stretch: normal;
-  font-style: normal;
-  line-height: 1.15;
-  font-family: 'SF Pro Display';
-  letter-spacing: normal;
-  text-align: left;
-  color: #6b829a;
-  --padding-bottom: 8px;
-  --padding-top: 9px;
-  --padding-end: 16px;
-  --padding-start: 16px;
-  --placeholder-color: var(--input - muted - placeholder);
-`;
 const About = styled.span`
-  margin: 9px 0 0 10px;
+  white-space: break-spaces !important;
+  margin: 9px 0 0 0;
   font-family: 'SF Pro Display';
   font-size: 14px;
   font-weight: normal;
@@ -75,9 +34,6 @@ const About = styled.span`
   color: #425466;
 `;
 
-const ModalFooter = styled(IonFooter)`
-  padding: 12px;
-`;
 interface IProps {
   mode?: string;
   update?: any;
@@ -118,7 +74,13 @@ const AboutCard: React.FC<IProps> = ({
           </IonGrid>
         </IonCardHeader>
         <IonCardContent>
-          <About>{about}</About>
+          <IonGrid>
+            <IonRow>
+              <IonCol size="12">
+                <About>{about}</About>
+              </IonCol>
+            </IonRow>
+          </IonGrid>
         </IonCardContent>
       </IonCard>
       <MyModal isOpen={isEditing} cssClass="my-custom-class">

--- a/src/components/cards/WidgetCards.module.scss
+++ b/src/components/cards/WidgetCards.module.scss
@@ -1,11 +1,10 @@
 .overview {
   background-color: #fff;
   border-radius: 16px;
-  min-height: 250px;
-  box-shadow: 0 3px 8px -1px rgba(50, 50, 71, 0.05), 0 0 1px 0 rgba(12, 26, 75, 0.24);
-  padding-bottom: 15px;
-  margin-top:10px;
-  margin-bottom: 20px;
+  box-shadow: 0 3px 8px -1px rgba(50, 50, 71, 0.05),
+    0 0 1px 0 rgba(12, 26, 75, 0.24);
+  margin-top: 22px;
+  margin-bottom: 22px;
 
   ion-card-title {
     font-family: 'SF Pro Display';
@@ -18,22 +17,17 @@
     text-align: left;
     color: #27272e;
   }
-
-  // .card-content {
-  // }
-
-  // .card-button {
-  // }
 }
 
 .popover-class {
   --width: 90px;
   --padding: 25px 20px 25px 20px;
-  --box-shadow: 0 5px 5px -3px rgba(0,0,0,0.2),0 8px 10px 1px rgba(100,100,100,0.14),0 3px 8px 2px rgba(100,100,100,0.12);
+  --box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
+    0 8px 10px 1px rgba(100, 100, 100, 0.14),
+    0 3px 8px 2px rgba(100, 100, 100, 0.12);
   .popover-content {
     background: white;
     --width: 90px;
     --padding: 10px;
   }
-  
 }

--- a/src/components/cards/common.tsx
+++ b/src/components/cards/common.tsx
@@ -1,6 +1,11 @@
-import { IonFooter, IonGrid, IonModal, IonTextarea } from '@ionic/react';
+import {
+  IonFooter,
+  IonCard,
+  IonGrid,
+  IonModal,
+  IonTextarea
+} from '@ionic/react';
 import styled from 'styled-components';
-import { toEditorSettings } from 'typescript';
 
 export enum MODE {
   NONE,
@@ -67,6 +72,7 @@ export const LinkStyleSpan = styled.span`
 `;
 
 export const Description = styled.span`
+  white-space: break-spaces !important;
   font-family: 'SF Pro Display';
   font-size: 13px;
   font-weight: normal;


### PR DESCRIPTION
- enable new lines on about/education/experience description
- fix & unify style of about/education/experience cards
![3](https://user-images.githubusercontent.com/36276559/112569991-ed8dce00-8e30-11eb-8b65-486cfc9a510c.png)
