### PR TITLE
Bug 555 fix

### DIFF
--- a/src/pages/DashboardPage/index.tsx
+++ b/src/pages/DashboardPage/index.tsx
@@ -102,7 +102,10 @@ const ProfilePage: React.FC<InferMappedProps> = ({
         props.session.did
       );
 
-      if (!publishWaiting) return;
+      if (!publishWaiting) {
+        clearInterval(timer);
+        return;
+      }
 
       let actual = await AssistService.refreshRequestStatus(
         publishWaiting.confirmationId,


### PR DESCRIPTION
To verify and update the user status we set a 5s interval on dashboard to check publishing status and update user session and vault. 

When we publish a diddocument, we set a flag on local storage to store the status.

In the case of a mnemonics user creation, we don't publish it, so we never set this status. When we use the tutorial, we try to find the status but we don't, so we return. 

In the case of a user creation from scratch, we find the status and we continue the execution, where we  eventually clear the timer, which never happens in the mnemonics case.  

So to avoid the refresh function being called when it shouldn't (overriding the session set during Tutorial, including tutorialstep), we need to:

- Clear interval to avoid executing refresh twice

Resolves #555 
