### PR TITLE
Change method to request credentials from essentials users

### DIFF
--- a/src/pages/Auth/SignInPage/index.tsx
+++ b/src/pages/Auth/SignInPage/index.tsx
@@ -40,11 +40,11 @@ const SignInPage: React.FC<RouteComponentProps<
   > => {
     console.log('Entering on connect');
     let didAccess = new DID.DIDAccess();
+
     try {
-      return await didAccess.getCredentials({
-        claims: {
-          name: true
-        }
+      return await didAccess.requestCredentials({
+        claims: [DID.simpleIdClaim('Your name', 'name', true)],
+        didMustBePublished: true
       });
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
 - The old method from connectivity SDK was deprecated and causing some problems