### PR TITLE
Fix social profiles to essentials users

### DIFF
--- a/src/components/cards/SocialProfileCard/index.tsx
+++ b/src/components/cards/SocialProfileCard/index.tsx
@@ -8,10 +8,8 @@ import { setSession } from 'src/store/users/actions';
 import { InferMappedProps, SubState } from './types';
 
 import SocialCard from './SocialCard';
-import { DIDDocument } from '@elastosfoundation/did-js-sdk/';
 
 interface Props extends InferMappedProps {
-  didDocument: DIDDocument;
   targetUser?: ISessionItem;
   setSession: (props: { session: ISessionItem }) => void;
   mode?: string;
@@ -21,12 +19,11 @@ interface Props extends InferMappedProps {
 const SocialProfiles: React.FC<Props> = ({ eProps, ...props }: Props) => {
   const user = props.targetUser ? props.targetUser : props.session;
 
-  if (props.mode === 'edit' || props.didDocument.getCredentialCount() > 0) {
+  if (props.mode === 'edit') {
     return (
       <SocialCard
         sessionItem={user}
         setSession={props.setSession}
-        diddocument={props.didDocument}
         mode={props.mode}
         openModal={props.openModal}
       />

--- a/src/components/profile/ProfileComponent/index.tsx
+++ b/src/components/profile/ProfileComponent/index.tsx
@@ -282,7 +282,6 @@ const ProfileComponent: React.FC<Props> = ({
                         {publicFields.includes('social') && didDocument && (
                           <SocialProfilesCard
                             setSession={() => {}}
-                            didDocument={didDocument}
                             targetUser={publicUser}
                           />
                         )}

--- a/src/pages/Auth/SocialCallback/DiscordCallback/index.tsx
+++ b/src/pages/Auth/SocialCallback/DiscordCallback/index.tsx
@@ -24,8 +24,6 @@ import { requestDiscordToken, getUsersWithRegisteredDiscord } from './fetchapi';
 import { ProfileService } from 'src/services/profile.service';
 import { CredentialType, DidcredsService } from 'src/services/didcreds.service';
 import { DidService } from 'src/services/did.service.new';
-import { DID, DIDDocument } from '@elastosfoundation/did-js-sdk/';
-import { EssentialsService } from 'src/services/essentials.service';
 
 interface PageProps
   extends InferMappedProps,
@@ -69,34 +67,6 @@ const DiscordCallback: React.FC<PageProps> = ({
             discord
           );
 
-          let didDocument: DIDDocument = await didService.getStoredDocument(
-            new DID(props.session.did)
-          );
-
-          let documentWithDiscordCredential: DIDDocument;
-
-          if (props.session.mnemonics === '') {
-            let essentialsService = new EssentialsService(didService);
-            let isAdded = await essentialsService.addVerifiableCredentialEssentials(
-              verifiableCredential
-            );
-
-            if (!isAdded) {
-              window.close();
-              return;
-            }
-
-            documentWithDiscordCredential = await didService.getPublishedDocument(
-              new DID(props.session.did)
-            );
-          } else {
-            documentWithDiscordCredential = await didService.addVerifiableCredentialToDIDDocument(
-              didDocument,
-              verifiableCredential
-            );
-          }
-
-          await didService.storeDocument(documentWithDiscordCredential);
           await DidcredsService.addOrUpdateCredentialToVault(
             props.session,
             verifiableCredential

--- a/src/pages/Auth/SocialCallback/FacebookCallback/index.tsx
+++ b/src/pages/Auth/SocialCallback/FacebookCallback/index.tsx
@@ -32,8 +32,6 @@ import {
 import { DidService } from 'src/services/did.service.new';
 import { ProfileService } from 'src/services/profile.service';
 import { DidcredsService, CredentialType } from 'src/services/didcreds.service';
-import { DID, DIDDocument } from '@elastosfoundation/did-js-sdk/';
-import { EssentialsService } from 'src/services/essentials.service';
 
 interface PageProps
   extends InferMappedProps,
@@ -77,32 +75,6 @@ const FacebookCallback: React.FC<PageProps> = ({
             facebookId.name
           );
 
-          let didDocument: DIDDocument = await didService.getStoredDocument(
-            new DID(props.session.did)
-          );
-          let documentWithFacebookCredential: DIDDocument;
-          if (props.session.mnemonics === '') {
-            let essentialsService = new EssentialsService(didService);
-            let isAdded = await essentialsService.addVerifiableCredentialEssentials(
-              verifiableCredential
-            );
-
-            if (!isAdded) {
-              window.close();
-              return;
-            }
-
-            documentWithFacebookCredential = await didService.getPublishedDocument(
-              new DID(props.session.did)
-            );
-          } else {
-            documentWithFacebookCredential = await didService.addVerifiableCredentialToDIDDocument(
-              didDocument,
-              verifiableCredential
-            );
-          }
-
-          await didService.storeDocument(documentWithFacebookCredential);
           await DidcredsService.addOrUpdateCredentialToVault(
             props.session,
             verifiableCredential

--- a/src/pages/Auth/SocialCallback/GithubCallback/index.tsx
+++ b/src/pages/Auth/SocialCallback/GithubCallback/index.tsx
@@ -24,8 +24,6 @@ import { requestGithubToken, getUsersWithRegisteredGithub } from './fetchapi';
 import { DidService } from 'src/services/did.service.new';
 import { ProfileService } from 'src/services/profile.service';
 import { DidcredsService, CredentialType } from 'src/services/didcreds.service';
-import { DID, DIDDocument } from '@elastosfoundation/did-js-sdk/';
-import { EssentialsService } from 'src/services/essentials.service';
 
 interface PageProps
   extends InferMappedProps,
@@ -63,34 +61,6 @@ const GithubCallback: React.FC<PageProps> = ({
             github
           );
 
-          let didDocument: DIDDocument = await didService.getStoredDocument(
-            new DID(props.session.did)
-          );
-
-          let documentWithGithubCredential: DIDDocument;
-
-          if (props.session.mnemonics === '') {
-            let essentialsService = new EssentialsService(didService);
-            let isAdded = await essentialsService.addVerifiableCredentialEssentials(
-              verifiableCredential
-            );
-
-            if (!isAdded) {
-              window.close();
-              return;
-            }
-
-            documentWithGithubCredential = await didService.getPublishedDocument(
-              new DID(props.session.did)
-            );
-          } else {
-            documentWithGithubCredential = await didService.addVerifiableCredentialToDIDDocument(
-              didDocument,
-              verifiableCredential
-            );
-          }
-
-          await didService.storeDocument(documentWithGithubCredential);
           await DidcredsService.addOrUpdateCredentialToVault(
             props.session,
             verifiableCredential

--- a/src/pages/Auth/SocialCallback/GoogleCallback/index.tsx
+++ b/src/pages/Auth/SocialCallback/GoogleCallback/index.tsx
@@ -30,8 +30,6 @@ import { AccountType, UserService } from 'src/services/user.service';
 import { ProfileService } from 'src/services/profile.service';
 import { CredentialType, DidcredsService } from 'src/services/didcreds.service';
 import { DidService } from 'src/services/did.service.new';
-import { DID, DIDDocument } from '@elastosfoundation/did-js-sdk/';
-import { EssentialsService } from 'src/services/essentials.service';
 
 interface PageProps
   extends InferMappedProps,
@@ -82,34 +80,6 @@ const GoogleCallback: React.FC<PageProps> = ({
             googleId.email
           );
 
-          let didDocument: DIDDocument = await didService.getStoredDocument(
-            new DID(props.session.did)
-          );
-
-          let documentWithGoogleCredential: DIDDocument;
-
-          if (props.session.mnemonics === '') {
-            let essentialsService = new EssentialsService(didService);
-            let isAdded = await essentialsService.addVerifiableCredentialEssentials(
-              verifiableCredential
-            );
-
-            if (!isAdded) {
-              window.close();
-              return;
-            }
-
-            documentWithGoogleCredential = await didService.getPublishedDocument(
-              new DID(props.session.did)
-            );
-          } else {
-            documentWithGoogleCredential = await didService.addVerifiableCredentialToDIDDocument(
-              didDocument,
-              verifiableCredential
-            );
-          }
-
-          await didService.storeDocument(documentWithGoogleCredential);
           await DidcredsService.addOrUpdateCredentialToVault(
             props.session,
             verifiableCredential

--- a/src/pages/Auth/SocialCallback/LinkedinCallback/index.tsx
+++ b/src/pages/Auth/SocialCallback/LinkedinCallback/index.tsx
@@ -34,8 +34,6 @@ import {
 import { DidService } from 'src/services/did.service.new';
 import { ProfileService } from 'src/services/profile.service';
 import { DidcredsService, CredentialType } from 'src/services/didcreds.service';
-import { DID, DIDDocument } from '@elastosfoundation/did-js-sdk/';
-import { EssentialsService } from 'src/services/essentials.service';
 
 interface PageProps
   extends InferMappedProps,
@@ -88,34 +86,6 @@ const LinkedinCallback: React.FC<PageProps> = ({
             firstName + '' + lastName
           );
 
-          let didDocument: DIDDocument = await didService.getStoredDocument(
-            new DID(props.session.did)
-          );
-
-          let documentWithLinkedinCredential: DIDDocument;
-
-          if (props.session.mnemonics === '') {
-            let essentialsService = new EssentialsService(didService);
-            let isAdded = await essentialsService.addVerifiableCredentialEssentials(
-              verifiableCredential
-            );
-
-            if (!isAdded) {
-              window.close();
-              return;
-            }
-
-            documentWithLinkedinCredential = await didService.getPublishedDocument(
-              new DID(props.session.did)
-            );
-          } else {
-            documentWithLinkedinCredential = await didService.addVerifiableCredentialToDIDDocument(
-              didDocument,
-              verifiableCredential
-            );
-          }
-
-          await didService.storeDocument(documentWithLinkedinCredential);
           await DidcredsService.addOrUpdateCredentialToVault(
             props.session,
             verifiableCredential

--- a/src/pages/Auth/SocialCallback/TwitterCallback/index.tsx
+++ b/src/pages/Auth/SocialCallback/TwitterCallback/index.tsx
@@ -28,8 +28,6 @@ import { CredentialType, DidcredsService } from 'src/services/didcreds.service';
 import { AccountType, UserService } from 'src/services/user.service';
 
 import { requestTwitterToken, getUsersWithRegisteredTwitter } from './fetchapi';
-import { DID, DIDDocument } from '@elastosfoundation/did-js-sdk/';
-import { EssentialsService } from 'src/services/essentials.service';
 
 interface PageProps
   extends InferMappedProps,
@@ -85,34 +83,6 @@ const TwitterCallback: React.FC<PageProps> = ({
             items[1].toString()
           );
 
-          let didDocument: DIDDocument = await didService.getStoredDocument(
-            new DID(props.session.did)
-          );
-
-          let documentWithTwitterCredential: DIDDocument;
-
-          if (props.session.mnemonics === '') {
-            let essentialsService = new EssentialsService(didService);
-            let isAdded = await essentialsService.addVerifiableCredentialEssentials(
-              verifiableCredential
-            );
-
-            if (!isAdded) {
-              window.close();
-              return;
-            }
-
-            documentWithTwitterCredential = await didService.getPublishedDocument(
-              new DID(props.session.did)
-            );
-          } else {
-            documentWithTwitterCredential = await didService.addVerifiableCredentialToDIDDocument(
-              didDocument,
-              verifiableCredential
-            );
-          }
-
-          await didService.storeDocument(documentWithTwitterCredential);
           await DidcredsService.addOrUpdateCredentialToVault(
             props.session,
             verifiableCredential

--- a/src/pages/DashboardPage/components/DashboardContent/index.tsx
+++ b/src/pages/DashboardPage/components/DashboardContent/index.tsx
@@ -5,7 +5,6 @@ import { TabsContainer } from 'src/components/profile/ProfileComponent/PublicPro
 import DashboardHome from './Home';
 // import DashboardStatus from './Status';
 import DashboardBadges from './Badges';
-import { DIDDocument } from '@elastosfoundation/did-js-sdk/';
 import SyncBar from 'src/components/SyncBar';
 import styled from 'styled-components';
 

--- a/src/pages/ManagerPage/components/ProfileEditor/index.tsx
+++ b/src/pages/ManagerPage/components/ProfileEditor/index.tsx
@@ -322,7 +322,6 @@ const ProfileEditor: React.FC<Props> = ({
                 )}
 
                 <SocialProfilesCard
-                  didDocument={didDocument as DIDDocument}
                   targetUser={session}
                   setSession={updateSession}
                   mode="edit"

--- a/src/pages/SyncPage/index.tsx
+++ b/src/pages/SyncPage/index.tsx
@@ -91,7 +91,9 @@ const SyncPage: React.FC<InferMappedProps> = ({
               </IonCol>
               <IonCol size="10" className={style['right-panel']}>
                 <Header>
-                  <ArrowImage onClick={() => (window.location.href = '/')}>
+                  <ArrowImage
+                    onClick={() => (window.location.href = '/profile')}
+                  >
                     <IonImg src={arrowLeft}></IonImg>
                   </ArrowImage>
                   <HeaderInfo>

--- a/src/services/didcreds.service.ts
+++ b/src/services/didcreds.service.ts
@@ -1,4 +1,7 @@
-import { VerifiableCredential } from '@elastosfoundation/did-js-sdk/';
+import {
+  JSONObject,
+  VerifiableCredential
+} from '@elastosfoundation/did-js-sdk/';
 import request, { BaseplateResp } from 'src/baseplate/request';
 import { HiveService } from './hive.service';
 
@@ -150,5 +153,31 @@ export class DidcredsService {
     });
 
     console.log(hiveResponse);
+  }
+
+  static async getAllCredentialsToVault(
+    sessionItem: ISessionItem
+  ): Promise<Map<string, VerifiableCredential>> {
+    let hiveClient = await HiveService.getSessionInstance(sessionItem);
+    let hiveResponse = await hiveClient?.Scripting.RunScript<any>({
+      name: 'get_verifiable_credentials',
+      context: {
+        target_did: sessionItem.did,
+        target_app_did: `${process.env.REACT_APP_APPLICATION_ID}`
+      }
+    });
+
+    let response = new Map<string, VerifiableCredential>();
+
+    if (!hiveResponse?.isSuccess) return response;
+
+    var collection = hiveResponse.response.get_verifiable_credentials.items;
+
+    collection.forEach((item: { vc: string | JSONObject }) => {
+      var vc = VerifiableCredential.parse(item.vc);
+      response.set(vc.getId().toString(), vc);
+    });
+
+    return response;
   }
 }

--- a/src/services/script.service.ts
+++ b/src/services/script.service.ts
@@ -4,7 +4,6 @@ import { UserVaultScripts } from 'src/scripts/uservault.script';
 import { UserService } from './user.service';
 import { HiveService } from './hive.service';
 import { DidService } from './did.service.new';
-import { alertError } from 'src/utils/notify';
 import { getItemsFromData } from 'src/utils/script';
 import { Guid } from 'guid-typescript';
 

--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -48,27 +48,7 @@ export class SyncService {
   private static async GetVerifiableCredentialsFromVault(
     sessionItem: ISessionItem
   ): Promise<Map<string, VerifiableCredential>> {
-    let hiveClient = await HiveService.getSessionInstance(sessionItem);
-    let hiveResponse = await hiveClient?.Scripting.RunScript<any>({
-      name: 'get_verifiable_credentials',
-      context: {
-        target_did: sessionItem.did,
-        target_app_did: `${process.env.REACT_APP_APPLICATION_ID}`
-      }
-    });
-
-    let response = new Map<string, VerifiableCredential>();
-
-    if (!hiveResponse?.isSuccess) return response;
-
-    var collection = hiveResponse.response.get_verifiable_credentials.items;
-
-    collection.forEach((item: { vc: string | JSONObject }) => {
-      var vc = VerifiableCredential.parse(item.vc);
-      response.set(vc.getId().toString(), vc);
-    });
-
-    return response;
+    return DidcredsService.getAllCredentialsToVault(sessionItem);
   }
 
   private static async GetVerifiableCredentialsFromRecentDocument(


### PR DESCRIPTION
Fix the way our social profiles feature works. Before we used the diddocument to storage and manage user's social profiles like discord, but it´s not work when the user is logged with essentials. To bypass this problem, we now always use user vault verifiable_credentials collection to storage and manage user's social profiles.