### PR TITLE
remove walletconnect item from localstorage

### DIFF
--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -630,6 +630,7 @@ export class UserService {
   public static logout() {
     window.localStorage.removeItem('isLoggedIn');
     window.localStorage.removeItem('persist:root');
+    window.localStorage.removeItem('walletconnect');
     window.location.href = '/';
   }
 


### PR DESCRIPTION
When sign-out from Profile, remove walletconnect item from localstorage.

That should prevent getting stuck on Profile when we try to Sign in using essentials after a long period of inactivity.