### PR TITLE
fix update badges when social login change

### DIFF
--- a/src/Atoms/Atoms.tsx
+++ b/src/Atoms/Atoms.tsx
@@ -1,6 +1,6 @@
 import { atom } from 'recoil';
 import { defaultFullProfile } from 'src/services/profile.service';
-import { defaultUserInfo } from 'src/store/users/types';
+import { defaultBadges, defaultUserInfo } from 'src/store/users/types';
 
 export const DIDDocumentAtom = atom({
   key: 'DIDDocument',
@@ -10,6 +10,11 @@ export const DIDDocumentAtom = atom({
 export const SessionAtom = atom({
   key: 'Session',
   default: defaultUserInfo
+});
+
+export const BadgesAtom = atom({
+  key: 'Badges',
+  default: defaultBadges
 });
 
 export const FullProfileAtom = atom({

--- a/src/components/cards/SocialProfileCard/SocialCard.tsx
+++ b/src/components/cards/SocialProfileCard/SocialCard.tsx
@@ -36,6 +36,8 @@ import {
 } from '../common';
 
 import { VerifiableCredential } from '@elastosfoundation/did-js-sdk/';
+import { useSetRecoilState } from 'recoil';
+import { BadgesAtom } from 'src/Atoms/Atoms';
 
 interface Props {
   sessionItem: ISessionItem;
@@ -50,6 +52,7 @@ const SocialProfilesCard: React.FC<Props> = ({
   mode = 'view',
   openModal = false
 }) => {
+  const setBadges = useSetRecoilState(BadgesAtom);
   const [isManagerOpen, setIsManagerOpen] = useState(openModal);
   const [isRemoving, setIsRemoving] = useState<boolean>(false);
   const [credentials, setCredentials] = useState<
@@ -116,6 +119,13 @@ const SocialProfilesCard: React.FC<Props> = ({
     var timer = setInterval(async function() {
       if (popupwindow!.closed) {
         await getCredentials(sessionItem);
+
+        let userService = new UserService(await DidService.getInstance());
+
+        let user: ISessionItem = await userService.SearchUserWithDID(
+          sessionItem.did
+        );
+        setBadges(user.badges as IBadges);
       }
     }, 1000);
   };

--- a/src/pages/Auth/SignInPage/index.tsx
+++ b/src/pages/Auth/SignInPage/index.tsx
@@ -43,7 +43,7 @@ const SignInPage: React.FC<RouteComponentProps<
     VerifiablePresentation | undefined
   > => {
     let connector: EssentialsConnector = connectivity.getActiveConnector() as EssentialsConnector;
-    if (connector.hasWalletConnectSession()) {
+    if (connector && connector.hasWalletConnectSession()) {
       connector.disconnectWalletConnect();
     }
 

--- a/src/pages/DashboardPage/components/DashboardContent/Badges/BadgeCard.tsx
+++ b/src/pages/DashboardPage/components/DashboardContent/Badges/BadgeCard.tsx
@@ -13,6 +13,8 @@ import style from './BadgeCard.module.scss';
 import ProgressBar from 'src/elements/ProgressBar';
 import BadgeItem from './BadgeItem';
 import badgeDetails from 'src/data/badge_detail.json';
+import { useRecoilValue } from 'recoil';
+import { BadgesAtom } from 'src/Atoms/Atoms';
 
 const ProgressBarChart = styled.div`
   width: 42px;
@@ -35,12 +37,14 @@ interface Props {
   badgeCategory: string;
 }
 
-const BadgeCard: React.FC<Props> = ({ badges, badgeCategory }) => {
+const BadgeCard: React.FC<Props> = ({ badgeCategory }) => {
   const [totalBadgeCount, setTotalBadgeCount] = useState<number>(0);
   const [completedBadgeCount, setCompletedBadgeCount] = useState<number>(0);
   const [progressPercent, setProgressPercent] = useState<number>(0);
   const [badgeItems, setBadgeItems] = useState<any>({});
   const [badgeCategoryTitle, setBadgeCategoryTitle] = useState<string>('');
+
+  const badges = useRecoilValue(BadgesAtom);
 
   useEffect(() => {
     if (!badges) return;

--- a/src/pages/DashboardPage/components/DashboardContent/Badges/index.tsx
+++ b/src/pages/DashboardPage/components/DashboardContent/Badges/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { IonCol, IonGrid, IonRow } from '@ionic/react';
 
 import style from './style.module.scss';
@@ -6,31 +6,34 @@ import style from './style.module.scss';
 import OverviewCard from './OverviewCard';
 import RecentBadgeCard from './RecentBadgeCard';
 import BadgeCard from './BadgeCard';
+import { useRecoilState } from 'recoil';
+import { BadgesAtom } from 'src/Atoms/Atoms';
 
 interface Props {
   sessionItem: ISessionItem;
 }
 
 const DashboardBadges: React.FC<Props> = ({ sessionItem }) => {
+  const [badges, setBadges] = useRecoilState<IBadges>(BadgesAtom);
+
+  useEffect(() => {
+    setBadges(sessionItem.badges as IBadges);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionItem]);
+
   return (
     <IonGrid className={style['tab-grid']}>
       <IonRow>
         <IonCol size="4">
-          <OverviewCard badges={sessionItem.badges!} />
+          <OverviewCard badges={badges} />
           {/* <ProfileCompletion /> */}
-          <RecentBadgeCard badges={sessionItem.badges!} />
+          <RecentBadgeCard badges={badges} />
         </IonCol>
         <IonCol size="8">
-          <BadgeCard badges={sessionItem.badges!} badgeCategory="account" />
-          <BadgeCard
-            badges={sessionItem.badges!}
-            badgeCategory="socialVerify"
-          />
-          <BadgeCard
-            badges={sessionItem.badges!}
-            badgeCategory="didPublishTimes"
-          />
-          <BadgeCard badges={sessionItem.badges!} badgeCategory="dStorage" />
+          <BadgeCard badges={badges} badgeCategory="account" />
+          <BadgeCard badges={badges} badgeCategory="socialVerify" />
+          <BadgeCard badges={badges} badgeCategory="didPublishTimes" />
+          <BadgeCard badges={badges} badgeCategory="dStorage" />
         </IonCol>
       </IonRow>
     </IonGrid>

--- a/src/store/users/types.ts
+++ b/src/store/users/types.ts
@@ -22,3 +22,33 @@ export const defaultUserInfo: ISessionItem = {
   pageTemplate: 'default',
   timestamp: Date.now()
 };
+
+export const defaultBadges: IBadges = {
+  account: {
+    beginnerTutorial: { archived: false },
+    basicProfile: { archived: false },
+    educationProfile: { archived: false },
+    experienceProfile: { archived: false }
+  },
+  socialVerify: {
+    linkedin: { archived: false },
+    facebook: { archived: false },
+    twitter: { archived: false },
+    google: { archived: false },
+    github: { archived: false },
+    discord: { archived: false },
+    email: { archived: false },
+    phone: { archived: false }
+  },
+  didPublishTimes: {
+    _1times: { archived: false },
+    _5times: { archived: false },
+    _10times: { archived: false },
+    _25times: { archived: false },
+    _50times: { archived: false },
+    _100times: { archived: false }
+  },
+  dStorage: {
+    ownVault: { archived: false }
+  }
+};


### PR DESCRIPTION
When social login changed, i.e, google added, we update tuumtech vault to assign a badge to the user, but we didn't reflected that change in dashboard badges tab, unless this tab were never loaded, in this case it would work, because we would loaded the already updated badges.

To solve this I created a Badges atom state to keep those values always updated.

Resolves #622   